### PR TITLE
Fix backup

### DIFF
--- a/backup/Dockerfile
+++ b/backup/Dockerfile
@@ -1,9 +1,7 @@
-FROM debian:jessie
+FROM python:2
 RUN apt-get -qq update && apt-get -qq install -y \
       cron \
       mysql-client \
-      python \
-      python-pip \
       rsync
 
 ENV TZ=Asia/Kolkata


### PR DESCRIPTION
The python installation for the backup image was broken for some reason - I didn't investigate too much because there's now an official Python Docker image, which we can use.

This bug meant that the last backup was taken in June - it's pretty scary that we didn't know about it. I'll add some tests to try to catch backup breakages.