### PR TITLE
backup: use full path for python

### DIFF
--- a/backup/run_backup.sh
+++ b/backup/run_backup.sh
@@ -10,7 +10,7 @@ set +a
 
 wiki_root="/srv/mediawiki"
 file="$wiki_root/LocalSettings.php"
-backup_to_dropbox="python /root/backup_to_dropbox.py"
+backup_to_dropbox="/usr/local/bin/python /root/backup_to_dropbox.py"
 
 timestamp=$(date +%Y_%m_%d_%H_%M_%S)
 backups_path="/root/backups"


### PR DESCRIPTION
Cron jobs run non-interactively and don't pick up the path from the
environment.