### PR TITLE
Upgrade to mediawiki 1.29

### DIFF
--- a/mediawiki/Dockerfile
+++ b/mediawiki/Dockerfile
@@ -4,15 +4,15 @@ RUN apt-get -qq update && apt-get -qq install -y \
       git wget unzip
 
 WORKDIR /tmp
-RUN wget -q https://releases.wikimedia.org/mediawiki/1.28/mediawiki-1.28.2.tar.gz \
-      && tar -xzf mediawiki-1.28.2.tar.gz \
+RUN wget -q https://releases.wikimedia.org/mediawiki/1.29/mediawiki-1.29.1.tar.gz \
+      && tar -xzf mediawiki-1.29.1.tar.gz \
       && mkdir -p /srv \
-      && mv /tmp/mediawiki-1.28.2 /srv/mediawiki
-
-COPY LocalSettings.php install_composer.sh composer.local.json /srv/mediawiki/
+      && mv /tmp/mediawiki-1.29.1 /srv/mediawiki
 
 COPY install_extensions.sh post_install.sh /tmp/
 RUN /tmp/install_extensions.sh
+
+COPY LocalSettings.php install_composer.sh composer.local.json /srv/mediawiki/
 
 WORKDIR /srv/mediawiki
 

--- a/mediawiki/LocalSettings.php
+++ b/mediawiki/LocalSettings.php
@@ -148,12 +148,12 @@ $wgSMTP = array(
     'auth' => true
 );
 
-require_once "$IP/extensions/ParserFunctions/ParserFunctions.php";
-require_once "$IP/extensions/Cite/Cite.php";
+wfLoadExtension('ParserFunctions');
+wfLoadExtension('Cite');
 require_once "$IP/extensions/RecentPages/RecentPages.php";
-wfLoadExtension("WikimediaMessages");
+wfLoadExtension('WikimediaMessages');
 
-require_once "$IP/extensions/WikiEditor/WikiEditor.php";
+wfLoadExtension('WikiEditor');
 $wgDefaultUserOptions['usebetatoolbar'] = 1;
 $wgDefaultUserOptions['usebetatoolbar-cgd'] = 1;
 $wgDefaultUserOptions['wikieditor-preview'] = 1;
@@ -166,8 +166,8 @@ $wgScribuntoUseGeSHi = true;
 $wgLocaltimezone = "Asia/Kolkata";
 date_default_timezone_set( $wgLocaltimezone );
 
-require_once "$IP/extensions/Gadgets/Gadgets.php";
-require_once "$IP/extensions/Echo/Echo.php";
+wfLoadExtension('Gadgets');
+wfLoadExtension('Echo');
 
 require_once "$IP/extensions/googleAnalytics/googleAnalytics.php";
 $wgGoogleAnalyticsAccount = 'UA-62532508-2';
@@ -183,7 +183,7 @@ $wgGroupPermissions['bot']['noanalytics'] = true;
 # $wgSquidServers = array('127.0.0.1');
 # $wgUsePrivateIPs = true;
 
-require_once "$IP/extensions/MobileFrontend/MobileFrontend.php";
+wfLoadExtension('MobileFrontend');
 $wgMFAutodetectMobileView = true;
 
 require_once "$IP/extensions/ContributionScores/ContributionScores.php";
@@ -200,7 +200,7 @@ $wgContribScoreReports = array(
 $wgMaxShellMemory = 307200;
 $wgMaxImageArea = 1250000000; // 1.25e9
 
-require_once "$IP/extensions/SyntaxHighlight_GeSHi/SyntaxHighlight_GeSHi.php";
+wfLoadExtension('SyntaxHighlight_GeSHi');
 
 /*$wgResourceLoaderMaxage['unversioned'] = array(
   'server' => 7 * 24 * 60 * 60, // one week
@@ -309,7 +309,7 @@ require_once("$IP/extensions/OpenGraphMeta/OpenGraphMeta.php");
 */
 wfLoadExtension( 'CommonsMetadata' );
 require_once "$IP/extensions/MultimediaViewer/MultimediaViewer.php";
-require_once "$IP/extensions/Poem/Poem.php";
+wfLoadExtension('Poem');
 
 # File upload permissions
 $wgGroupPermissions['user']['upload'] = false;

--- a/mediawiki/install_extensions.sh
+++ b/mediawiki/install_extensions.sh
@@ -2,25 +2,34 @@
 
 set -xe
 
-declare -a extensions=( \
-    WikimediaMessages-REL1_28-d742c36 \
-    Scribunto-REL1_28-a665621 \
-    Echo-REL1_28-f55bdd9 \
-    googleAnalytics-REL1_28-6dd4ae5 \
-    MobileFrontend-REL1_28-a0c8024 \
-    ContributionScores-REL1_28-703f4f3 \
-    CommonsMetadata-REL1_28-e3c0bbe \
-    MultimediaViewer-REL1_28-b426dc3 \
-    SandboxLink-REL1_28-aa109b7 \
-    CheckUser-REL1_28-95fe8e0 \
-    AbuseFilter-REL1_28-c3be1ce \
+declare -a extension_names=( \
+    AbuseFilter \
+    CheckUser \
+    CommonsMetadata \
+    ContributionScores \
+    Echo \
+    MobileFrontend \
+    MultimediaViewer \
+    SandboxLink \
+    Scribunto \
+    WikimediaMessages \
+    googleAnalytics \
 )
 
+MEDIAWIKI_RELEASE=REL1_29
+
+function fetch_extension_url() {
+    curl -s "https://www.mediawiki.org/wiki/Special:ExtensionDistributor?extdistname=$1&extdistversion=$MEDIAWIKI_RELEASE" \
+        | grep -oP 'https://extdist.wmflabs.org/dist/extensions/.*?.tar.gz' \
+        | head -1
+}
+
 cd /tmp
-for extension in "${extensions[@]}"; do
-    IFS=- read extension_name _ <<< "$extension"
-    wget -q "https://extdist.wmflabs.org/dist/extensions/$extension.tar.gz"
-    tar -xzf "$extension.tar.gz"
+for extension_name in "${extension_names[@]}"; do
+    versioned_extension_url=$(fetch_extension_url $extension_name)
+    versioned_extension_name=$(echo $versioned_extension_url | awk -F"/" '{print $(NF)}')
+    wget -q $versioned_extension_url
+    tar -xzf "$versioned_extension_name"
     mv $extension_name /srv/mediawiki/extensions/
 done
 


### PR DESCRIPTION
Modify the extensions installation script so that future upgrades are a simple matter of changing the `MEDIAWIKI_RELEASE` variable.

Fixes #28.