### PR TITLE
Move images to the static volume

### DIFF
--- a/backup/run_backup.sh
+++ b/backup/run_backup.sh
@@ -9,6 +9,7 @@ source .env
 set +a
 
 wiki_root="/srv/mediawiki"
+static_root="/srv/static"
 file="$wiki_root/LocalSettings.php"
 backup_to_dropbox="/usr/local/bin/python /root/backup_to_dropbox.py"
 
@@ -24,7 +25,7 @@ sed -i '$ d' $file
 
 # backup images on the 21st of every month
 if [[ $(date '+%d') == "21" ]]; then
-    rsync -a "$wiki_root/images" "$backups_path/$backup_dir/" --exclude thumb --exclude temp
+    rsync -a "$static_root/images" "$backups_path/$backup_dir/" --exclude thumb --exclude temp
 fi
 
 cd $backups_path

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -4,6 +4,12 @@ services:
   nginx:
     volumes:
       - static-volume:/srv/static
+  php:
+    volumes:
+      - static-volume:/srv/static
+  mediawiki:
+    volumes:
+      - static-volume:/srv/static
   backup:
     build: './backup'
     links:
@@ -13,6 +19,7 @@ services:
       - DROPBOX_ACCESS_TOKEN=$DROPBOX_ACCESS_TOKEN
     volumes:
       - mediawiki-volume:/srv/mediawiki
+      - static-volume:/srv/static
   jobs:
     build: './jobs'
     environment:

--- a/mediawiki/Dockerfile
+++ b/mediawiki/Dockerfile
@@ -21,6 +21,8 @@ RUN ./install_composer.sh \
       && php composer.phar update --no-dev --optimize-autoloader --no-suggest --no-progress
 
 COPY assets/ resources/assets/
+
+RUN mkdir -p /srv/static/images && rm -rf images && ln -s /srv/static/images images
 RUN mkdir -p images/temp
 
 ENTRYPOINT /tmp/post_install.sh

--- a/mediawiki/post_install.sh
+++ b/mediawiki/post_install.sh
@@ -4,4 +4,4 @@ set -xe
 
 # TODO figure out when to run
 # cd /srv/mediawiki/maintenance && php update.php
-chown -R www-data:www-data /srv/mediawiki
+chown -LR www-data:www-data /srv/mediawiki


### PR DESCRIPTION
This change makes the mediawiki volume completely ephemeral, and allows us to safely upload images and other files.

`/srv/mediawiki/images` is symlinked to `/srv/static/images`.