### PR TITLE
Run a job from the queue every request

### DIFF
--- a/mediawiki/LocalSettings.php
+++ b/mediawiki/LocalSettings.php
@@ -260,7 +260,8 @@ $wgGroupPermissions['no-captcha']['skipcaptcha'] = true;
 # 3 wrong captchas allowed every 10 minutes per IP
 $wgRateLimits['badcaptcha']['ip'] = array( 3, 10 * 60 );
 
-$wgJobRunRate = 0;
+$wgJobRunRate = 1;
+$wgRunJobsAsync = true;
 
 $wgUseFileCache = true;
 $wgFileCacheDirectory = "$IP/cache";


### PR DESCRIPTION
While digging around on the server I discovered over 7k jobs that
hadn't been run, because we'd configured the job run rate to be
zero (presumably with the intention of running jobs via cron).

Set this to run one job every request, which should be fine at our
level of traffic. Also enable async execution so that requests aren't
slowed down.