### PR TITLE
Deduplicate pages between the "Popular pages" and "Trending pages" template

### DIFF
--- a/jobs/pywikibot/scripts/updatestatistics.py
+++ b/jobs/pywikibot/scripts/updatestatistics.py
@@ -148,6 +148,10 @@ def deduplicate_lists(list_to_dedup, base_list):
     base_list
 
     will maintain the order of elements in list_to_dedup
+
+    1. forms a dictionary of all the elements in list_to_dedup
+    2. iterates over the elements in base_list and removes them from
+    list_to_dedup if they are there in the dictionary
     '''
 
     dict_from_list = OrderedDict.fromkeys(list_to_dedup)

--- a/jobs/pywikibot/scripts/updatestatistics.py
+++ b/jobs/pywikibot/scripts/updatestatistics.py
@@ -165,8 +165,9 @@ def main():
     # Authenticate and construct service.
     service = get_service('analytics', 'v3', scope, key_file_env)
     profile = get_first_profile_id(service)
+
     popular_pages = get_popular_pages(service, profile)
-    #  update_list_of_pages('Template:Popular_pages', popular_pages)
+    update_list_of_pages('Template:Popular_pages', popular_pages)
 
     trending_pages = get_trending_pages(service, profile)
     trending_pages_deduped = deduplicate_lists( \
@@ -174,16 +175,7 @@ def main():
                                 popular_pages[:REQD_TEMPLATE_LEN] \
                             )
     
-    print
-    print
-    print "Popular"
-    print '\n'.join(popular_pages[:REQD_TEMPLATE_LEN])
-    print
-    print
-    print "Trending"
-    print '\n'.join(trending_pages_deduped[:REQD_TEMPLATE_LEN])
-
-    #  update_list_of_pages('Template:Trending_pages', trending_pages)
+    update_list_of_pages('Template:Trending_pages', trending_pages_deduped)
 
 if __name__ == '__main__':
     main()

--- a/jobs/pywikibot/scripts/updatestatistics.py
+++ b/jobs/pywikibot/scripts/updatestatistics.py
@@ -148,18 +148,15 @@ def deduplicate_lists(list_to_dedup, base_list):
     base_list
 
     will maintain the order of elements in list_to_dedup
-
-    1. forms a dictionary of all the elements in list_to_dedup
-    2. iterates over the elements in base_list and removes them from
-    list_to_dedup if they are there in the dictionary
     '''
 
-    dict_from_list = OrderedDict.fromkeys(list_to_dedup)
-    for elem in base_list:
-        if elem in dict_from_list:
-            list_to_dedup.remove(elem)
+    deduped_list = [ ]
+    base_dict = OrderedDict.fromkeys(base_list)
+    for elem in list_to_dedup:
+        if not elem in base_dict:
+            deduped_list.append(elem)
 
-    return list_to_dedup
+    return deduped_list
 
 def main():
     # Define the auth scopes to request.

--- a/jobs/pywikibot/scripts/updatestatistics.py
+++ b/jobs/pywikibot/scripts/updatestatistics.py
@@ -125,7 +125,7 @@ def get_trending_pages(service, profile_id):
 def update_list_of_pages(template, pages):
     template_page = pywikibot.Page(pywikibot.Link(template), pywikibot.Site())
     text = " <noinclude>This page is automatically generated. Changes will be overwritten, so '''do not modify'''.</noinclude>\n"
-    for p in pages[:REQD_TEMPLATE_LEN]:
+    for p in pages:
         text += "*[[%s]]\n" % p
     text = text.rstrip()
     if template_page.text == text:
@@ -167,13 +167,16 @@ def main():
     profile = get_first_profile_id(service)
 
     popular_pages = get_popular_pages(service, profile)
+    popular_pages = popular_pages[:REQD_TEMPLATE_LEN]
+
     update_list_of_pages('Template:Popular_pages', popular_pages)
 
     trending_pages = get_trending_pages(service, profile)
     trending_pages_deduped = deduplicate_lists( \
                                 trending_pages, \
-                                popular_pages[:REQD_TEMPLATE_LEN] \
+                                popular_pages \
                             )
+    trending_pages_deduped = trending_pages_deduped[:REQD_TEMPLATE_LEN]
     
     update_list_of_pages('Template:Trending_pages', trending_pages_deduped)
 

--- a/jobs/pywikibot/scripts/updatestatistics.py
+++ b/jobs/pywikibot/scripts/updatestatistics.py
@@ -11,8 +11,6 @@ import json
 
 import pywikibot
 
-from collections import OrderedDict
-
 REQD_TEMPLATE_LEN = 10
 
 def get_service(api_name, api_version, scopes, key_file_env):
@@ -150,11 +148,10 @@ def deduplicate_lists(list_to_dedup, base_list):
     will maintain the order of elements in list_to_dedup
     '''
 
-    deduped_list = [ ]
-    base_dict = OrderedDict.fromkeys(base_list)
-    for elem in list_to_dedup:
-        if not elem in base_dict:
-            deduped_list.append(elem)
+    # convert to set for O(1) membership checking
+    base_set = set(base_list)
+
+    deduped_list = [x for x in list_to_dedup if not x in base_set]
 
     return deduped_list
 

--- a/jobs/pywikibot/scripts/updatestatistics.py
+++ b/jobs/pywikibot/scripts/updatestatistics.py
@@ -11,6 +11,7 @@ import json
 
 import pywikibot
 
+REQD_TEMPLATE_LEN = 10
 
 def get_service(api_name, api_version, scopes, key_file_env):
     """Get a service that communicates to a Google API.
@@ -88,11 +89,7 @@ def filter_main_ns(results):
         if match.group(1) in pages:
             continue
 
-        #print 'r: ', r
-
         pages.append(match.group(1))
-        if len(pages) == 10:
-            break
 
     return pages
 
@@ -126,7 +123,7 @@ def get_trending_pages(service, profile_id):
 def update_list_of_pages(template, pages):
     template_page = pywikibot.Page(pywikibot.Link(template), pywikibot.Site())
     text = " <noinclude>This page is automatically generated. Changes will be overwritten, so '''do not modify'''.</noinclude>\n"
-    for p in pages:
+    for p in pages[:REQD_TEMPLATE_LEN]:
         text += "*[[%s]]\n" % p
     text = text.rstrip()
     if template_page.text == text:


### PR DESCRIPTION
- Takes the list of popular pages that we have updated to the template
- Removes any element in `Trending pages` that also occurs in popular pages
- Updates the template to show the required number of trending pages

Fix #30 