### PR TITLE
Add ArticleFeedbackv5

### DIFF
--- a/mediawiki/LocalSettings.php
+++ b/mediawiki/LocalSettings.php
@@ -449,3 +449,7 @@ $wgGroupPermissions['whitelisted-bot']['editprotected'] = true;
 # Maps extension; installed through composer
 $GLOBALS['egMapsGMaps3ApiKey'] = getenv('GOOGLE_MAPS_API_KEY', true);
 $GLOBALS['egMapsDefaultService'] = 'googlemaps3';
+
+# ArticleFeedbackv5
+wfLoadExtension( 'ArticleFeedbackv5' );
+$wgArticleFeedbackv5LotteryOdds = 100;

--- a/mediawiki/install_extensions.sh
+++ b/mediawiki/install_extensions.sh
@@ -4,6 +4,7 @@ set -xe
 
 declare -a extension_names=( \
     AbuseFilter \
+    ArticleFeedbackv5 \
     CheckUser \
     CommonsMetadata \
     ContributionScores \


### PR DESCRIPTION
This has [worked well](https://blog.wikimedia.org/2012/12/20/article-feedback-new-research-and-next-steps/) for collecting feedback for wikipedia, and might be useful to encourage more participation and a lower entry barrier compared to edits.

Will require running `maintenance/update.php` after installation to create the necessary database tables.