### PR TITLE
Change the way `graphicsmagick` is used for creating thumbnails; include SimpleBatchUpload extension

### DIFF
--- a/mediawiki/Dockerfile
+++ b/mediawiki/Dockerfile
@@ -1,7 +1,7 @@
 FROM php:7-fpm
 
 RUN apt-get -qq update && apt-get -qq install -y \
-      git wget unzip
+      git wget unzip graphicsmagick
 
 WORKDIR /tmp
 RUN wget -q https://releases.wikimedia.org/mediawiki/1.30/mediawiki-1.30.0.tar.gz \

--- a/mediawiki/Dockerfile
+++ b/mediawiki/Dockerfile
@@ -22,6 +22,8 @@ RUN ./install_composer.sh \
 
 COPY assets/ resources/assets/
 
+COPY gmconvert.sh /opt/
+
 RUN mkdir -p /srv/static/images && rm -rf images && ln -s /srv/static/images images
 RUN mkdir -p images/temp
 

--- a/mediawiki/Dockerfile
+++ b/mediawiki/Dockerfile
@@ -1,7 +1,7 @@
 FROM php:7-fpm
 
 RUN apt-get -qq update && apt-get -qq install -y \
-      git wget unzip graphicsmagick
+      git wget unzip
 
 WORKDIR /tmp
 RUN wget -q https://releases.wikimedia.org/mediawiki/1.30/mediawiki-1.30.0.tar.gz \

--- a/mediawiki/LocalSettings.php
+++ b/mediawiki/LocalSettings.php
@@ -88,9 +88,6 @@ $wgEnableUploads = true;
 $wgUseImageMagick = false;
 $wgCustomConvertCommand = "/usr/bin/gm convert %s -resize %wx%h %d";
 
-$wgSVGConverters['GraphicMagick'] = '/usr/bin/gm convert -background none -thumbnail $widthx$height\! $input PNG:$output';
-$wgSVGConverter = 'GraphicMagick';
-
 # For extension PdfHandler
 $wgPdfPostProcessor = "/opt/gmconvert.sh";
 

--- a/mediawiki/LocalSettings.php
+++ b/mediawiki/LocalSettings.php
@@ -82,7 +82,7 @@ $wgMemCachedServers = [];
 
 ## To enable image uploads, make sure the 'images' directory
 ## is writable, then set this to true:
-// $wgTmpDirectory = "$IP/images/temp";
+$wgTmpDirectory = "$IP/images/temp";
 $wgEnableUploads = true;
 
 $wgUseImageMagick = false;

--- a/mediawiki/LocalSettings.php
+++ b/mediawiki/LocalSettings.php
@@ -443,6 +443,8 @@ $wgGroupPermissions['sysop']['abusefilter-private'] = true;
 $wgGroupPermissions['sysop']['abusefilter-modify-restricted'] = true;
 $wgGroupPermissions['sysop']['abusefilter-revert'] = true;
 
+wfLoadExtension( 'SimpleBatchUpload' );
+
 # Bots
 $wgGroupPermissions['whitelisted-bot']['editprotected'] = true;
 

--- a/mediawiki/LocalSettings.php
+++ b/mediawiki/LocalSettings.php
@@ -82,10 +82,17 @@ $wgMemCachedServers = [];
 
 ## To enable image uploads, make sure the 'images' directory
 ## is writable, then set this to true:
-$wgTmpDirectory = "$IP/images/temp";
+// $wgTmpDirectory = "$IP/images/temp";
 $wgEnableUploads = true;
-$wgUseImageMagick = true;
-$wgImageMagickConvertCommand = "/usr/bin/gm";
+
+$wgUseImageMagick = false;
+$wgCustomConvertCommand = "/usr/bin/gm convert %s -resize %wx%h %d";
+
+$wgSVGConverters['GraphicMagick'] = '/usr/bin/gm convert -background none -thumbnail $widthx$height\! $input PNG:$output';
+$wgSVGConverter = 'GraphicMagick';
+
+# For extension PdfHandler
+$wgPdfPostProcessor = "/opt/gmconvert.sh";
 
 # InstantCommons allows wiki to use images from http://commons.wikimedia.org
 $wgUseInstantCommons = true;

--- a/mediawiki/composer.local.json
+++ b/mediawiki/composer.local.json
@@ -14,6 +14,7 @@
       "pimple/pimple": "~2.1",
       "ruflin/elastica": "~3.1",
       "symfony/process": "~3.0",
-      "wikimedia/textcat": "~1.1"
+      "wikimedia/textcat": "~1.1",
+      "mediawiki/simple-batch-upload": "~1.3"
   }
 }

--- a/mediawiki/gmconvert.sh
+++ b/mediawiki/gmconvert.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+gm convert $@


### PR DESCRIPTION
I have tested this now. Uploading an image immediately generates it's thumbnail.

The `SimpleBatchUpload` extension will work well for us. I uploaded images that are missing (downloaded from the old snapshot we had) and they automatically appeared on pages that they were missing from.