### PR TITLE
move from links to networks

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -12,8 +12,8 @@ services:
       - static-volume:/srv/static
   backup:
     build: './backup'
-    links:
-      - mysql:mysql-docker
+    networks:
+      mysql_network:
     environment:
       - MYSQL_PASSWORD=$MYSQL_PASSWORD
       - DROPBOX_ACCESS_TOKEN=$DROPBOX_ACCESS_TOKEN
@@ -29,3 +29,6 @@ services:
 volumes:
   mediawiki-volume:
   static-volume:
+
+networks:
+  mysql_network:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,13 @@ version: '2.1'
 services:
   mysql:
     image: 'mysql:5.7'
+    networks:
+      mysql_network:
+        aliases:
+          - mysql-docker
+      data_network:
+        aliases:
+          - mysql-docker
     environment:
       - MYSQL_RANDOM_ROOT_PASSWORD=true
       - MYSQL_DATABASE=metakgp_wiki_db
@@ -10,13 +17,15 @@ services:
       - MYSQL_PASSWORD=${MYSQL_PASSWORD}
   nginx:
     build: './nginx'
-    links:
-      - php:php-docker
+    networks:
+      main_network:
   php:
     build: './php'
-    links:
-      - mysql:mysql-docker
-      - parsoid:parsoid-docker
+    networks:
+      data_network:
+      main_network:
+        aliases:
+          - php-docker
     environment:
       - MAILGUN_PASSWORD=$MAILGUN_PASSWORD
       - RECAPTCHA_SECRET_KEY=$RECAPTCHA_SECRET_KEY
@@ -31,3 +40,12 @@ services:
     build: './mediawiki'
   parsoid:
     build: './parsoid'
+    networks:
+      data_network:
+        aliases:
+          - parsoid-docker
+
+networks:
+  main_network:
+  mysql_network:
+  data_network:


### PR DESCRIPTION
links is deprecated in Docker: https://docs.docker.com/network/links/

![image](https://user-images.githubusercontent.com/3668034/48311144-c37c3e00-e5de-11e8-8a6f-a02ffae13626.png)

This is the network diagram (the arrows represent the old links, and the annotations near the arrows represent the name of the network that allows those connections)

![Imgur](https://i.imgur.com/ooJlTQJ.jpg)

I tested this by running docker-compose locally, and then opening the wiki and making an edit / checking that pages were there. (I used a mysql backup of the wiki to test this stuff)
