### PR TITLE
Update mediawiki to 1.32.2

### DIFF
--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -2,7 +2,7 @@
 
 ## Deploying to prod
 
-0. Take a backup! Run `docker-compose exec backup run_backup.sh` and make sure it succeeded. Also run `git log` and note down the current deployed sha, in case you need to roll back.
+0. Take a backup! Run `docker-compose -f docker-compose.yml -f docker-compose.override.yml -f docker-compose.prod.yml exec backup ./run_backup.sh` and make sure it succeeded. Also run `git log` and note down the current deployed sha, in case you need to roll back.
 0. `git pull` and `docker-compose build`. This builds and caches the new images locally without interrupting the old server, which reduces downtime.
 0. `docker-compose down` shuts down the server and removes containers. Now downtime has started ticking.
 0. `docker volume rm <mediawiki-volume>`, so that the mediawiki container can create a new volume with updates in the next step.
@@ -28,15 +28,16 @@ $ docker-compose -f docker-compose.yml -f docker-compose.override.yml -f docker-
 ### I want to retrieve the latest backup
 
 ```sh
-# ensure that the backup container is running
+# ensure that the backup container is running and drop into the container's bash
 $ docker-compose -f docker-compose.yml -f docker-compose.override.yml -f docker-compose.prod.yml exec backup /bin/bash
-# this will drop you into the container's bash
+# below command will create a new backup of the server
 container $ ./run_backup.sh
-container $ ls /root/backups # to ensure that the backup tar was created
+# to ensure that the backup tar was created
+container $ ls /root/backups 
 container $ exit
 # now copy the created tar file into the host filesystem
 # docker cp doesn't take wildcard paths (??)
-$ docker cp metakgpwiki_backup_1:/root/backups/metakgpwiki_2017_10_23_10_11_44.tar.gz .
+$ docker cp metakgp-wiki_backup_1:/root/backups/metakgpwiki_2017_10_23_10_11_44.tar.gz .
 $ pwd
 ```
 

--- a/mediawiki/Dockerfile
+++ b/mediawiki/Dockerfile
@@ -4,10 +4,10 @@ RUN apt-get -qq update && apt-get -qq install -y \
       git wget unzip
 
 WORKDIR /tmp
-RUN wget -q https://releases.wikimedia.org/mediawiki/1.30/mediawiki-1.30.0.tar.gz \
-      && tar -xzf mediawiki-1.30.0.tar.gz \
+RUN wget -q https://releases.wikimedia.org/mediawiki/1.32/mediawiki-1.32.2.tar.gz \
+      && tar -xzf mediawiki-1.32.2.tar.gz \
       && mkdir -p /srv \
-      && mv /tmp/mediawiki-1.30.0 /srv/mediawiki
+      && mv /tmp/mediawiki-1.32.2 /srv/mediawiki
 
 COPY install_extensions.sh post_install.sh /tmp/
 RUN /tmp/install_extensions.sh

--- a/mediawiki/install_extensions.sh
+++ b/mediawiki/install_extensions.sh
@@ -58,4 +58,4 @@ wget -q https://github.com/leucosticte/RecentPages/archive/master.zip \
     && mv RecentPages/RecentPages-master /srv/mediawiki/extensions/RecentPages
 
 # Make Lua executable
-chmod a+x /srv/mediawiki/extensions/Scribunto/engines/LuaStandalone/binaries/lua5_1_5_linux_64_generic/lua
+chmod a+x /srv/mediawiki/extensions/Scribunto/includes/engines/LuaStandalone/binaries/lua5_1_5_linux_64_generic/lua

--- a/mediawiki/install_extensions.sh
+++ b/mediawiki/install_extensions.sh
@@ -10,7 +10,6 @@ declare -a extension_names=( \
     ContributionScores \
     Echo \
     MobileFrontend \
-    MultimediaViewer \
     SandboxLink \
     Scribunto \
     VisualEditor \

--- a/mediawiki/install_extensions.sh
+++ b/mediawiki/install_extensions.sh
@@ -22,7 +22,7 @@ declare -a skin_names=( \
     MinervaNeue \
 )
 
-MEDIAWIKI_RELEASE=REL1_30
+MEDIAWIKI_RELEASE=REL1_32
 
 function fetch_extension_url() {
     curl -s "https://www.mediawiki.org/wiki/Special:ExtensionDistributor?extdistname=$1&extdistversion=$MEDIAWIKI_RELEASE" \


### PR DESCRIPTION
- Version 1.30 is no more supported
- Update extensions accordingly

I'll use the following procedure once the PR is approved to update on prod.

- Take the latest backup of the server and store it locally.
- `git pull` and `docker-compose build`
- `docker-compose down`
- `docker volume rm <mediawiki-volume`
- `docker-compose -f docker-compose.yml -f docker-compose.override.yml -f docker-compose.prod.yml up --build -d`
- `docker-compose exec php /srv/mediawiki/maintenance/update.php`

@icyflame Please have a thorough look.

References:
- https://www.mediawiki.org/wiki/Manual:Upgrading