### PR TITLE
Fix tests using debian jessie

### DIFF
--- a/backup/Dockerfile
+++ b/backup/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:2
+FROM python:2-jessie
 RUN apt-get -qq update && apt-get -qq install -y \
       cron \
       mysql-client \

--- a/mediawiki/Dockerfile
+++ b/mediawiki/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7-fpm
+FROM php:7-fpm-jessie
 
 RUN apt-get -qq update && apt-get -qq install -y \
       git wget unzip

--- a/php/Dockerfile
+++ b/php/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7-fpm
+FROM php:7-fpm-jessie
 RUN apt-get -qq update && apt-get -qq install -y \
             build-essential \
             git-core \


### PR DESCRIPTION
[Debian Buster][1] was released about 10 days ago. Tests on `master` started failing because of this. (`buster`'s repository lists have not been updated with `mysql-client` repositories)

This PR locks us to Debian Jessie with which we know that our tests were passing. [Debian Jessie][2] was released in June 2018.

[Failed CI 1][3]
[Failed CI 2][4]
[Failed CI 3][5]

[1]: https://www.debian.org/releases/buster/
[2]: https://www.debian.org/releases/jessie/
[3]: https://travis-ci.org/metakgp/metakgp-wiki/builds/559424128#L850
[4]: https://travis-ci.org/metakgp/metakgp-wiki/builds/558903439#L850
[5]: https://travis-ci.org/metakgp/metakgp-wiki/builds/558514162#L850