### PR TITLE
[BUG-FIX] Make it so parsoid can contact nginx

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,7 @@ services:
   parsoid:
     build: './parsoid'
     networks:
+      main_network:
       data_network:
         aliases:
           - parsoid-docker


### PR DESCRIPTION
## Background

This bug was introduced in #49. Parsoid needs to contact nginx, but the networks were not set up correctly, which caused the visual editor to stop working.

### Cause

I tested the new setup locally but I was only testing the source edit function. Developers should remember to use both Source Edit and Visual Editor when making changes to the wiki because VE is a popular choice among many users (especially people who are new to the wiki / mediawiki markup language)

## Detection

After deploying the mediawiki update to 1.33, we realized that source edits were working but the Visual Editor was not working. The logs of the parsoid container had the reason for this error:

```sh
{"name":"parsoid","hostname":"a815b3504bee","pid":36,"level":60,"err":{"message":"Config Request failure for \"http://nginx/api.php\": Error: getaddrinfo ENOTFOUND nginx nginx:80","name":"lib/index.js","stack":"lib/index.js: Config Request failure for \"http://nginx/api.php\": Error: getaddrinfo ENOTFOUND nginx nginx:80\n    at ConfigRequest.ApiRequest._requestCB (/home/parsoid/parsoid/lib/mw/ApiRequest.js:415:15)\n    at self.callback (/home/parsoid/parsoid/node_modules/request/request.js:185:22)\n    at emitOne (events.js:116:13)\n    at Request.emit (events.js:211:7)\n    at Request.onRequestError (/home/parsoid/parsoid/node_modules/request/request.js:877:8)\n    at emitOne (events.js:121:20)\n    at ClientRequest.emit (events.js:211:7)\n    at Socket.socketErrorListener (_http_client.js:387:9)\n    at emitOne (events.js:116:13)\n    at Socket.emit (events.js:211:7)\n    at emitErrorNT (internal/streams/destroy.js:64:8)\n    at _combinedTickCallback (internal/process/next_tick.js:138:11)\n    at process._tickCallback (internal/process/next_tick.js:180:9)","levelPath":"fatal/request"},"msg":"Config Request failure for \"http://nginx/api.php\": Error: getaddrinfo ENOTFOUND nginx nginx:80","time":"2019-07-17T01
```

## Action Items

- Add a test to integration tests which checks if the Visual Editor is working properly ( #63 )

## Mitigation

- Deploy this fix