### PR TITLE
allow sending remote ip to google recaptcha servers

### DIFF
--- a/mediawiki/LocalSettings.php
+++ b/mediawiki/LocalSettings.php
@@ -221,6 +221,7 @@ wfLoadExtensions( array( 'ConfirmEdit', 'ConfirmEdit/ReCaptchaNoCaptcha' ) );
 $wgCaptchaClass = 'ReCaptchaNoCaptcha';
 $wgReCaptchaSiteKey = '6LdItAoTAAAAALJJ011ZgHC5tna4r2DIkVYu9jyR';
 $wgReCaptchaSecretKey = getenv('RECAPTCHA_SECRET_KEY', true);
+$wgReCaptchaSendRemoteIP = true;
 
 # Present captcha by default
 $wgCaptchaTriggers['edit'] = true;


### PR DESCRIPTION
The PR enables sending of remote IP of the wiki user to ReCaptcha servers for higher level of security and banning of already detected spamming IPs.

https://www.mediawiki.org/wiki/Extension:ConfirmEdit