### PR TITLE
Add StopForumSpam extension

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -25,6 +25,8 @@ services:
     environment:
       - BATMAN_BOT_PASSWORD=$BATMAN_BOT_PASSWORD
       - GOOGLE_ANALYTICS_SERVICE_KEY=$GOOGLE_ANALYTICS_SERVICE_KEY
+    volumes:
+      - mediawiki-volume:/srv/mediawiki
 
 volumes:
   mediawiki-volume:

--- a/jobs/Dockerfile
+++ b/jobs/Dockerfile
@@ -28,6 +28,6 @@ COPY pywikibot/user-config.py pywikibot/user-password.py pywikibot/
 COPY pywikibot/metakgp_family.py pywikibot/pywikibot/families/
 COPY pywikibot/scripts/ pywikibot/scripts/
 
-COPY crontab update_top_trending.sh MetaMaint.sh ./
+COPY crontab update_top_trending.sh MetaMaint.sh update_spam_blacklist.sh ./
 
 CMD ["supercronic", "/root/crontab"]

--- a/jobs/crontab
+++ b/jobs/crontab
@@ -2,3 +2,4 @@
 
 11 * * * * /root/update_top_trending.sh
 * * * * 1 /root/MetaMaint.sh
+47 3 * * * /root/update_spam_blacklist.sh

--- a/jobs/update_spam_blacklist.sh
+++ b/jobs/update_spam_blacklist.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -xe
+
+echo "Updating spam blacklist"
+
+cd /tmp && rm -f /tmp/listed_ip_30_ipv46* && \
+    wget -q https://www.stopforumspam.com/downloads/listed_ip_30_ipv46.zip \
+    && unzip listed_ip_30_ipv46.zip -d listed_ip_30_ipv46 \
+    && rm -rf /srv/mediawiki/extensions/StopForumSpam/listed_ip_30_ipv46 \
+    && mv listed_ip_30_ipv46 /srv/mediawiki/extensions/StopForumSpam/ \
+    && chown -R www-data:www-data /srv/mediawiki/extensions/StopForumSpam/listed_ip_30_ipv46

--- a/mediawiki/LocalSettings.php
+++ b/mediawiki/LocalSettings.php
@@ -437,3 +437,7 @@ $GLOBALS['egMapsDefaultService'] = 'googlemaps3';
 # ArticleFeedbackv5
 wfLoadExtension( 'ArticleFeedbackv5' );
 $wgArticleFeedbackv5LotteryOdds = 100;
+
+# StopForumSpam
+wfLoadExtension( 'StopForumSpam' );
+$wgSFSIPListLocation = "$IP/extensions/StopForumSpam/listed_ip_30_ipv46/listed_ip_30_ipv46.txt";

--- a/mediawiki/install_extensions.sh
+++ b/mediawiki/install_extensions.sh
@@ -12,6 +12,7 @@ declare -a extension_names=( \
     MobileFrontend \
     SandboxLink \
     Scribunto \
+    StopForumSpam \
     VisualEditor \
     WikimediaMessages \
     googleAnalytics \
@@ -59,3 +60,8 @@ wget -q https://github.com/leucosticte/RecentPages/archive/master.zip \
 
 # Make Lua executable
 chmod a+x /srv/mediawiki/extensions/Scribunto/includes/engines/LuaStandalone/binaries/lua5_1_5_linux_64_generic/lua
+
+# Download StopForumSpam blacklist
+wget -q https://www.stopforumspam.com/downloads/listed_ip_30_ipv46.zip \
+    && unzip listed_ip_30_ipv46.zip -d listed_ip_30_ipv46 \
+    && mv listed_ip_30_ipv46 /srv/mediawiki/extensions/StopForumSpam/listed_ip_30_ipv46

--- a/mediawiki/install_extensions.sh
+++ b/mediawiki/install_extensions.sh
@@ -64,4 +64,4 @@ chmod a+x /srv/mediawiki/extensions/Scribunto/includes/engines/LuaStandalone/bin
 # Download StopForumSpam blacklist
 wget -q https://www.stopforumspam.com/downloads/listed_ip_30_ipv46.zip \
     && unzip listed_ip_30_ipv46.zip -d listed_ip_30_ipv46 \
-    && mv listed_ip_30_ipv46 /srv/mediawiki/extensions/StopForumSpam/listed_ip_30_ipv46
+    && mv listed_ip_30_ipv46 /srv/mediawiki/extensions/StopForumSpam/

--- a/parsoid/Dockerfile
+++ b/parsoid/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8-jessie
+FROM node:10-jessie
 RUN apt-get -qq update && apt-get -qq install -y \
             git-core
 
@@ -8,7 +8,7 @@ WORKDIR /home/parsoid
 
 RUN git clone https://gerrit.wikimedia.org/r/p/mediawiki/services/parsoid && \
     cd parsoid && \
-    git checkout v0.8.1 && \
+    git checkout v0.10.0 && \
     npm install
 
 WORKDIR /home/parsoid/parsoid


### PR DESCRIPTION
This extension checks edits against an updated list of spammer IPs across various forums, and prevents edits and account creations from those IPs.

Set up nightly cron job to update spam blacklist.

Ran locally and confirmed that adding my local IP to the blacklist prevented me from editing. Also confirmed that the update cron job works as expected.