### PR TITLE
Use latest ArticleFeedbackv5

### DIFF
--- a/mediawiki/install_extensions.sh
+++ b/mediawiki/install_extensions.sh
@@ -18,6 +18,11 @@ declare -a extension_names=( \
     googleAnalytics \
 )
 
+declare -A extension_version_overrides=( \
+    # remove once we upgrade to mediawiki 1.34
+    ["ArticleFeedbackv5"]="master" \
+)
+
 declare -a skin_names=( \
     MinervaNeue \
 )
@@ -25,20 +30,24 @@ declare -a skin_names=( \
 MEDIAWIKI_RELEASE=REL1_33
 
 function fetch_extension_url() {
-    curl -s "https://www.mediawiki.org/wiki/Special:ExtensionDistributor?extdistname=$1&extdistversion=$MEDIAWIKI_RELEASE" \
+    curl -s "https://www.mediawiki.org/wiki/Special:ExtensionDistributor?extdistname=$1&extdistversion=$2" \
         | grep -oP 'https://extdist.wmflabs.org/dist/extensions/.*?.tar.gz' \
         | head -1
 }
 
 function fetch_skin_url() {
-    curl -s "https://www.mediawiki.org/wiki/Special:SkinDistributor?extdistname=$1&extdistversion=$MEDIAWIKI_RELEASE" \
+    curl -s "https://www.mediawiki.org/wiki/Special:SkinDistributor?extdistname=$1&extdistversion=$2" \
         | grep -oP 'https://extdist.wmflabs.org/dist/skins/.*?.tar.gz' \
         | head -1
 }
 
 cd /tmp
 for extension_name in "${extension_names[@]}"; do
-    versioned_extension_url=$(fetch_extension_url $extension_name)
+    version=$MEDIAWIKI_RELEASE
+    if [[ -v "extension_version_overrides[$extension_name]" ]]; then
+	version=${extension_version_overrides[$extension_name]}
+    fi
+    versioned_extension_url=$(fetch_extension_url $extension_name $version)
     versioned_extension_name=$(echo $versioned_extension_url | awk -F"/" '{print $(NF)}')
     wget -q $versioned_extension_url
     tar -xzf "$versioned_extension_name"
@@ -46,7 +55,7 @@ for extension_name in "${extension_names[@]}"; do
 done
 
 for skin_name in "${skin_names[@]}"; do
-    versioned_skin_url=$(fetch_skin_url $skin_name)
+    versioned_skin_url=$(fetch_skin_url $skin_name $MEDIAWIKI_RELEASE)
     versioned_skin_name=$(echo $versioned_skin_url | awk -F"/" '{print $(NF)}')
     wget -q $versioned_skin_url
     tar -xzf "$versioned_skin_name"

--- a/test/integration/run_tests.sh
+++ b/test/integration/run_tests.sh
@@ -89,8 +89,16 @@ $DOCKER_COMPOSE exec -T php php $WIKI/maintenance/install.php \
 # Move LocalSettings.php back in place
 $DOCKER_COMPOSE exec -T php mv $WIKI/LocalSettings.php.bak $WIKI/LocalSettings.php
 
+# CheckUser fails on a fresh install, move it out of the way
+$DOCKER_COMPOSE exec -T php sed -i '/wfLoadExtension.*CheckUser/s/^/#/g' $WIKI/LocalSettings.php
+$DOCKER_COMPOSE exec -T php mv $WIKI/extensions/CheckUser/maintenance $WIKI/extensions/CheckUser/maintenance.bak
+
 # Run update.php for creating any required tables
-$DOCKER_COMPOSE exec -T php php $WIKI/maintenance/update.php
+$DOCKER_COMPOSE exec -T php php $WIKI/maintenance/update.php --quick
+
+# Restore CheckUser
+$DOCKER_COMPOSE exec -T php sed -i '/wfLoadExtension.*CheckUser/s/^#//g' $WIKI/LocalSettings.php
+$DOCKER_COMPOSE exec -T php mv $WIKI/extensions/CheckUser/maintenance.bak $WIKI/extensions/CheckUser/maintenance
 
 
 # ----- Tests start here -----
@@ -109,7 +117,7 @@ fi
 
 # article feedback loads correctly
 AFV5_CURL_OUTPUT=$(curl -sSL $NGINX_ADDR'/w/Special:ArticleFeedbackv5')
-if [[ $AFV5 != *"Central Feedback Page"* ]]; then
+if [[ $AFV5_CURL_OUTPUT != *"Central Feedback Page"* ]]; then
     error "Article Feedback failed to load properly: "$AFV5_CURL_OUTPUT
 fi
 

--- a/test/integration/run_tests.sh
+++ b/test/integration/run_tests.sh
@@ -89,15 +89,30 @@ $DOCKER_COMPOSE exec -T php php $WIKI/maintenance/install.php \
 # Move LocalSettings.php back in place
 $DOCKER_COMPOSE exec -T php mv $WIKI/LocalSettings.php.bak $WIKI/LocalSettings.php
 
-# Sample test only; more comprehensive tests to follow
+# ----- Tests start here -----
+
+# main page loads correctly
 CURL_OUTPUT=$(curl -sSL $NGINX_ADDR)
 if [[ $CURL_OUTPUT != *"Powered by MediaWiki"* ]]; then
     error "Main page failed to load properly: "$CURL_OUTPUT
 fi
 
+# mobile main page loads correctly
 MOBILE_CURL_OUTPUT=$(curl -sSL $NGINX_ADDR'/index.php?title=Main_Page&mobileaction=toggle_view_mobile')
 if [[ $MOBILE_CURL_OUTPUT != *"Special:MobileMenu"* ]]; then
     error "Main page failed to load properly on mobile: "$MOBILE_CURL_OUTPUT
+fi
+
+# article feedback loads correctly
+AFV5_CURL_OUTPUT=$(curl -sSL $NGINX_ADDR'/w/Special:ArticleFeedbackv5')
+if [[ $AFV5 != *"Central Feedback Page"* ]]; then
+    error "Article Feedback failed to load properly: "$AFV5_CURL_OUTPUT
+fi
+
+# user contributions loads correctly
+CONTRIBS_CURL_OUTPUT=$(curl -sSL $NGINX_ADDR'/w/Special:Contributions/Admin')
+if [[ $CONTRIBS_CURL_OUTPUT != *"Search for contributions"* ]]; then
+    error "Contributions page failed to load properly: "$CONTRIBS_CURL_OUTPUT
 fi
 
 info "Tests complete"

--- a/test/integration/run_tests.sh
+++ b/test/integration/run_tests.sh
@@ -89,6 +89,10 @@ $DOCKER_COMPOSE exec -T php php $WIKI/maintenance/install.php \
 # Move LocalSettings.php back in place
 $DOCKER_COMPOSE exec -T php mv $WIKI/LocalSettings.php.bak $WIKI/LocalSettings.php
 
+# Run update.php for creating any required tables
+$DOCKER_COMPOSE exec -T php php $WIKI/maintenance/update.php
+
+
 # ----- Tests start here -----
 
 # main page loads correctly

--- a/test/integration/run_tests.sh
+++ b/test/integration/run_tests.sh
@@ -89,16 +89,14 @@ $DOCKER_COMPOSE exec -T php php $WIKI/maintenance/install.php \
 # Move LocalSettings.php back in place
 $DOCKER_COMPOSE exec -T php mv $WIKI/LocalSettings.php.bak $WIKI/LocalSettings.php
 
-# CheckUser fails on a fresh install, move it out of the way
+# CheckUser makes update.php fail on a fresh install, move it out of the way
 $DOCKER_COMPOSE exec -T php sed -i '/wfLoadExtension.*CheckUser/s/^/#/g' $WIKI/LocalSettings.php
-$DOCKER_COMPOSE exec -T php mv $WIKI/extensions/CheckUser/maintenance $WIKI/extensions/CheckUser/maintenance.bak
 
 # Run update.php for creating any required tables
 $DOCKER_COMPOSE exec -T php php $WIKI/maintenance/update.php --quick
 
 # Restore CheckUser
 $DOCKER_COMPOSE exec -T php sed -i '/wfLoadExtension.*CheckUser/s/^#//g' $WIKI/LocalSettings.php
-$DOCKER_COMPOSE exec -T php mv $WIKI/extensions/CheckUser/maintenance.bak $WIKI/extensions/CheckUser/maintenance
 
 
 # ----- Tests start here -----


### PR DESCRIPTION
This contains fixes for MW 1.33 and 1.34.

Ran locally and confirmed that the article feedback and user contributions pages work as expected. Added tests for these.