### PR TITLE
Clone only a single commit object when cloning parsoid

### DIFF
--- a/parsoid/Dockerfile
+++ b/parsoid/Dockerfile
@@ -6,10 +6,12 @@ RUN useradd --create-home --shell /bin/bash parsoid
 USER parsoid
 WORKDIR /home/parsoid
 
-RUN git clone https://gerrit.wikimedia.org/r/mediawiki/services/parsoid && \
-    cd parsoid && \
-    git checkout v0.10.0 && \
-    npm install
+RUN git clone \
+        --depth 1 \
+        --branch v0.10.0 \
+        https://gerrit.wikimedia.org/r/mediawiki/services/parsoid && \
+        cd parsoid && \
+        npm install
 
 WORKDIR /home/parsoid/parsoid
 COPY config.yaml ./


### PR DESCRIPTION
The complete Parsoid repository is huge and downloads nearly 68k git objects. We are using only v0.10.0. So, we should only clone that particular commit and not the complete git tree.

The `--depth 1 --branch ...` options for git-clone will tell the git server exactly what objects to return.

## Testing

- I ran this locally and ensured the visual edits work properly

## Comparison

```sh
$ git clone https://gerrit.wikimedia.org/r/mediawiki/services/parsoid
Cloning into 'parsoid'...
remote: Counting objects: 970, done
remote: Finding sources: 100% (48/48)
remote: Getting sizes: 100% (37/37)
remote: Compressing objects: 100% (2240708/2240708)
Receiving objects:   8% (5506/68823), 1.94 MiB | 559.00 KiB/s

$ git clone --depth 1 --branch v0.10.0 https://gerrit.wikimedia.org/r/mediawiki/services/parsoid
Cloning into 'parsoid'...
remote: Counting objects: 316, done
remote: Finding sources: 100% (316/316)
remote: Getting sizes: 100% (302/302)
remote: Compressing objects:  99% (14409/14410)
Receiving objects:  31% (98/316), 131.97 KiB | 212.00 KiB/s
```