### PR TITLE
Upgrade Mediawiki's version to 1.34

### DIFF
--- a/mediawiki/Dockerfile
+++ b/mediawiki/Dockerfile
@@ -4,10 +4,10 @@ RUN apt-get -qq update && apt-get -qq install -y \
       git wget unzip
 
 WORKDIR /tmp
-RUN wget -q https://releases.wikimedia.org/mediawiki/1.33/mediawiki-1.33.0.tar.gz \
-      && tar -xzf mediawiki-1.33.0.tar.gz \
+RUN wget -q https://releases.wikimedia.org/mediawiki/1.34/mediawiki-1.34.0.tar.gz \
+      && tar -xzf mediawiki-1.34.0.tar.gz \
       && mkdir -p /srv \
-      && mv /tmp/mediawiki-1.33.0 /srv/mediawiki
+      && mv /tmp/mediawiki-1.34.0 /srv/mediawiki
 
 COPY install_extensions.sh post_install.sh /tmp/
 RUN /tmp/install_extensions.sh

--- a/mediawiki/Dockerfile
+++ b/mediawiki/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7-fpm-jessie
+FROM php:7.3-fpm-buster
 
 RUN apt-get -qq update && apt-get -qq install -y \
       git wget unzip

--- a/mediawiki/LocalSettings.php
+++ b/mediawiki/LocalSettings.php
@@ -149,6 +149,15 @@ $wgSMTP = array(
 
 wfLoadExtension('ParserFunctions');
 wfLoadExtension('Cite');
+
+# RecentPages uses this constant. Starting PHP 7.2.0, referring to undefined
+# constants raises a warning and will eventually throw an error.
+# This value is used by RecentPages as the first argument to the wfGetDB global
+# function. This value MUST be an integer.
+if ( !defined( 'DB_SLAVE' ) ) {
+  define('DB_SLAVE', 0);
+}
+
 require_once "$IP/extensions/RecentPages/RecentPages.php";
 wfLoadExtension('WikimediaMessages');
 

--- a/mediawiki/LocalSettings.php
+++ b/mediawiki/LocalSettings.php
@@ -158,7 +158,6 @@ $wgDefaultUserOptions['usebetatoolbar-cgd'] = 1;
 $wgDefaultUserOptions['wikieditor-preview'] = 1;
 #$wgDefaultUserOptions['wikieditor-publish'] = 1;
 
-require_once "$IP/extensions/Scribunto/Scribunto.php";
 $wgScribuntoDefaultEngine = 'luastandalone';
 $wgScribuntoUseGeSHi = true;
 

--- a/mediawiki/install_extensions.sh
+++ b/mediawiki/install_extensions.sh
@@ -11,7 +11,6 @@ declare -a extension_names=( \
     Echo \
     MobileFrontend \
     SandboxLink \
-    Scribunto \
     StopForumSpam \
     VisualEditor \
     WikimediaMessages \

--- a/mediawiki/install_extensions.sh
+++ b/mediawiki/install_extensions.sh
@@ -27,7 +27,7 @@ declare -a skin_names=( \
     MinervaNeue \
 )
 
-MEDIAWIKI_RELEASE=REL1_33
+MEDIAWIKI_RELEASE=REL1_34
 
 function fetch_extension_url() {
     curl -s "https://www.mediawiki.org/wiki/Special:ExtensionDistributor?extdistname=$1&extdistversion=$2" \

--- a/mediawiki/install_extensions.sh
+++ b/mediawiki/install_extensions.sh
@@ -18,8 +18,6 @@ declare -a extension_names=( \
 )
 
 declare -A extension_version_overrides=( \
-    # remove once we upgrade to mediawiki 1.34
-    ["ArticleFeedbackv5"]="master" \
 )
 
 declare -a skin_names=( \

--- a/php/Dockerfile
+++ b/php/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7-fpm-jessie
+FROM php:7.3-fpm-buster
 RUN apt-get -qq update && apt-get -qq install -y \
             build-essential \
             git-core \


### PR DESCRIPTION
## Summary

The nightly Travis CI build has been failing for the past few days as ArticleFeedback doesn't support Mediawiki 1.33. Mediawiki 1.34 is now stable.

This PR updates the Mediawiki version to 1.34.

Every commit explains the reasons for the change. Here's a summary:

- Scribunto is shipped with mediawiki-core now, we don't need any configuration on our side
- PHP 7.1 is no longer supported (End-of-Life starting Dec 2019) => I updated the versions to PHP 7.3
- Debian Jessia is oldstable version, I upgraded it to the latest stable version: Debian Buster
- The RecentPages extension uses the PHP constant `DB_SLAVE` but this constant was never defined anywhere. PHP 7.2 starts raising a warning if we refer to an undefined constant. PHP 7.3 throws an error.
    - This value is passed as the first argument to `wfGetDB` by RecentPages. It _must_ be an integer.

![image](https://user-images.githubusercontent.com/3668034/75611149-36565300-5b5b-11ea-8838-f89eadd6b4cf.png)

Here's a summary of the process I went through during the upgrade:

<details>
<summary>Mediawiki 1.33 => 1.34 Upgrade summary</summary>
<pre>
This periodic failing build on Travis CI got to me

https://travis-ci.org/metakgp/metakgp-wiki/builds/656667168#L2620

I am making a PR to upgrade to Mediawiki 1.34.

icyflame  1 hour ago

- Scribunto is part of mediawiki core now
- We don't need to pull the master branch of ArticleFeedbackV5 anymore
- PHP 7 and 7.1 aren't supported  I upgraded to PHP 7.3 with Debian Buster (We
  were using Debian Jessie, which is two releases ago)
    - 7.1 => 7.3 had a couple of breaking changes: count(null) is an error now.
      Hopefully none of the extensions has some code like that

icyflame  1 hour ago

On the bright side though, 7.3 is supposed to have some major improvements
related to RAM usage. So, maybe our memory usage will go down from 90 => 80%?


icyflame  1 hour ago

Oh, Node 10 on Parsoid and Python 2 on Backup  We have to fix that.  I will
create a GitHub issue for each of them.

icyflame  1 hour ago

Issues created//github.com/metakgp/metakgp-wiki/issues/76
https://github.com/metakgp/metakgp-wiki/issues/77

icyflame  1 hour ago

I didn't remove all the Scribunto configuration  Removed and re-building now.

icyflame  39 minutes ago

Alright, we have our first customer: RecentPages has some strange code?

> 2020/02/29 15 PHP Warning:  Use of undefined constant DB_SLAVE - assumed
> 'DB_SLAVE' (this will throw an Error in a future version of PHP) in
> /srv/mediawiki/extensions/RecentPages/RecentPages.php on line 279" while
> reading response header from upstream, client wiki.metakgp.org, request9000",
> host8080"


icyflame  35 minutes ago

We are fetching the PHP file from
GitHubhttps://github.com/Inclumedia/RecentPages/blob/b7d863d2b862e70ebde0635e7845b4cba0d4db7e/RecentPages.php#L279

Code looks fine, maybe I just need to define DB_SLAVE?

icyflame  30 minutes ago


> If you use an undefined constant, PHP assumes that you mean the name of the
> constant itself, just as if you called it as a string (CONSTANT vs
> "CONSTANT"). This fallback is deprecated as of PHP 7.2.0, and an error of
> level E_WARNING is issued when it happens (previously, an error of level
> E_NOTICE has been issued instead.) See also the manual entry on why $foo[bar]
> is wrong (unless you first define() bar as a constant). This does not apply to
> (fully) qualified constants, which will raise a fatal error if undefined. If
> you simply want to check if a constant is set, use the defined() function.

-- https://www.php.net/manual/en/language.constants.syntax.php

So, we just need to explicitly define the DB_SLAVE constant and set it to the
value "DB_SLAVE" (edited)

icyflame  30 minutes ago

Done, re-building now;

icyflame  29 minutes ago

Didn't add a semicolon. I need a stricter PHP linter in my editor.  Fixed and
re-building

icyflame  23 minutes ago

All the pages except the main page work fine. Here we go.  (edited)

icyflame  15 minutes ago


> [4ffcc58250ce869ee5be1905] /w/Main_Page UnexpectedValueException from line 462
> of /srv/mediawiki/includes/libs/rdbms/loadbalancer/LoadBalancer.php: Invalid
> server index index #DB_SLAVE

Still looks like a RecentPages issue, the value I gave this constant was
incorrect?  I wonder what was the constant's value in the previous PHP version.
Perhaps, I should find that.

icyflame  13 minutes ago

https://doc.wikimedia.org/mediawiki-core/master/php/GlobalFunctions_8php.html#a46345f25555fd93d272119932fbfc18f

Ah, it should be an integer.

icyflame  8 minutes ago

AHA! WORKED! (edited)
</pre>
</details>