### PR TITLE
remove broken URL from CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,13 @@ While sending a PR, always remember not to send one from your master branch; it 
 
 It is highly recommended to follow the below guidelines while writing commits and sending PRs:
 
-- https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/
+- [Writing a good pull request][1] ([Archive][2])
+- [Writing good commit messages][3] ([Archive][4])
+
+[1]: https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/
+[2]: https://archive.is/EcSyE#selection-445.4-445.43
+[3]: https://code.likeagirl.io/useful-tips-for-writing-better-git-commit-messages-808770609503?gi=7c67de2ad7c0
+[4]: https://archive.is/W1h2O#selection-199.0-199.50
 
 ## Communication
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,6 @@ While sending a PR, always remember not to send one from your master branch; it 
 It is highly recommended to follow the below guidelines while writing commits and sending PRs:
 
 - https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/
-- https://code.likeagirl.io/useful-tips-for-writing-better-git-commit-messages-808770609503
 
 ## Communication
 


### PR DESCRIPTION
 The URL [https://code.likeagirl.io/useful-tips-for-writing-better-git-commit-messages-808770609503](https://code.likeagirl.io/useful-tips-for-writing-better-git-commit-messages-808770609503) under the **Sending a PR** heading is broken as the Medium story is removed by its author.  It is removed from _CONTRIBUTING.md_