### PR TITLE
Fix "session hijacking" login issue

### DIFF
--- a/mediawiki/LocalSettings.php
+++ b/mediawiki/LocalSettings.php
@@ -79,6 +79,8 @@ $wgDBmysql5 = false;
 ## Shared memory settings
 $wgMainCacheType = CACHE_ACCEL;
 $wgMemCachedServers = [];
+# Make sure logins work (https://phabricator.wikimedia.org/T147161)
+$wgSessionCacheType = CACHE_DB;
 
 ## To enable image uploads, make sure the 'images' directory
 ## is writable, then set this to true:


### PR DESCRIPTION
More details here https://www.mediawiki.org/wiki/Manual:Performance_tuning#Single_web_server

> If using $wgMainCacheType = CACHE_ACCEL; and users are unable to login due to "session hijacking" errors, consider overriding $wgSessionCacheType to CACHE_DB. See task T147161 for more info.