### PR TITLE
Add deploy script for quick and reliable deployments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .env
 .idea/
+.backups

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
-sudo: required
+os: linux
+dist: xenial
 
 services:
   - docker

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -25,7 +25,7 @@ command without that flag at the end.
 ### Deprecated
 
 **Note:** Manual operation for regular configuration updates is now deprecated. Please use the
-deploy script: <./script/deploy-latest.sh>
+deploy script: [./script/deploy-latest.sh](./script/deploy-latest.sh).
 
 1. Take a backup! Run `docker-compose -f docker-compose.yml -f docker-compose.override.yml -f docker-compose.prod.yml exec backup ./run_backup.sh` and make sure it succeeded. Also run `git log` and note down the current deployed sha, in case you need to roll back.
 1. `git pull` and `docker-compose build`. This builds and caches the new images locally without interrupting the old server, which reduces downtime.

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -13,6 +13,20 @@ Please follow below instructions in order to upgrade the mediawiki version. Refe
 
 ## Deploying to prod
 
+1. Run the deploy script
+
+``` sh
+$ sudo SLACK_NOTIFICATIONS_URL=$(SLACK_NOTIFICATIONS_URL) /root/metakgp-wiki/scripts/deploy-latest.sh --go
+```
+
+_Note:_ The `--go` flag indicates that the deployment will be completed. For a dry run, run the same
+command without that flag at the end.
+
+### Deprecated
+
+**Note:** Manual operation for regular configuration updates is now deprecated. Please use the
+deploy script: <./script/deploy-latest.sh>
+
 1. Take a backup! Run `docker-compose -f docker-compose.yml -f docker-compose.override.yml -f docker-compose.prod.yml exec backup ./run_backup.sh` and make sure it succeeded. Also run `git log` and note down the current deployed sha, in case you need to roll back.
 1. `git pull` and `docker-compose build`. This builds and caches the new images locally without interrupting the old server, which reduces downtime.
 1. `docker-compose -f docker-compose.yml -f docker-compose.override.yml -f docker-compose.prod.yml down` shuts down the server and removes containers. Now downtime has started ticking.
@@ -44,7 +58,7 @@ $ docker-compose -f docker-compose.yml -f docker-compose.override.yml -f docker-
 # below command will create a new backup of the server
 container $ ./run_backup.sh
 # to ensure that the backup tar was created
-container $ ls /root/backups 
+container $ ls /root/backups
 container $ exit
 # now copy the created tar file into the host filesystem
 # docker cp doesn't take wildcard paths (??)
@@ -115,7 +129,7 @@ $ docker volume prune
 
 ### I want to upgrade to a new mediawiki version
 
-You have to run `maintenance/update.php` after installing a new extension or 
+You have to run `maintenance/update.php` after installing a new extension or
 upgrading mediawiki. This will update the database tables as necessary.
 
 ```sh

--- a/scripts/deploy-latest.sh
+++ b/scripts/deploy-latest.sh
@@ -12,13 +12,29 @@ set -xe
 deploy_message () {
 	local action=$1
 	case $action in
-		"start")
+		"deploy_start")
 			echo "Deploy begin: User $(whoami) is deploying to metakgp-wiki"
 			;;
-		"end")
-			echo "Deploy end: Completed deployment"
+		"downtime_start")
+			echo "Downtime begin"
+			;;
+		"downtime_end")
+			echo "Downtime end"
+			;;
+		"deploy_end")
+			echo "Deploy end"
 			;;
 	esac
+}
+
+notify_slack () {
+	message="${1}"
+	if [[ -n "$SLACK_NOTIFICATIONS_URL" ]];
+	then
+		curl -s -H 'content-type: application/json' \
+			 -d "{ \"text\": \"${message}\" }" \
+			 "$SLACK_NOTIFICATIONS_URL"
+	fi
 }
 
 # TODO: Better as parameters to the deploy function?
@@ -27,6 +43,8 @@ deploy_branch="origin/master"
 
 deploy () {
 	local go="${1}"
+
+	notify_slack "$(deploy_message deploy_start)"
 
 	local source_dir=$(pwd)
 	echo "START: metakgp-wiki deploy"
@@ -48,14 +66,15 @@ deploy () {
 	local docker_compose="docker-compose"
 	local docker="docker"
 
-	# TODO: Fail if docker or docker-compose not found
-	${docker} version > /dev/null
-	${docker_compose} version > /dev/null
+	[[ -x "$(which ${docker})" ]]
+	[[ -x "$(which ${docker_compose})" ]]
 
 	echo "STEP: Running backup job"
-	local backup_container_exec="${docker_compose} -f docker-compose.yml \
+
+	local docker_compose_override="${docker_compose} -f docker-compose.yml \
 					  -f docker-compose.override.yml \
-					  -f docker-compose.prod.yml exec backup"
+					  -f docker-compose.prod.yml"
+	local backup_container_exec="${docker_compose_override} exec backup"
 
 	${backup_container_exec} ./run_backup.sh 2>/dev/null
 
@@ -87,13 +106,7 @@ deploy () {
 	echo "STEP: Build docker images for the new configuration"
 	${docker_compose_override} build
 
-	# TODO: Move to a function
-	if [[ -n "$SLACK_NOTIFICATIONS_URL" ]];
-	then
-		curl -s -H 'content-type: application/json' \
-			 -d "{ \"text\": \"$(deploy_message start)\" }" \
-			 "$SLACK_NOTIFICATIONS_URL"
-	fi
+	notify_slack "$(deploy_message downtime_start)"
 
 	echo "STEP: Bring all containers down"
 	${docker_compose_override} down
@@ -108,14 +121,13 @@ deploy () {
 
 	echo "STEP: All containers are up (Downtime end) $(date +%s)"
 
-	# TODO: Move to a function
-	if [[ -n "$SLACK_NOTIFICATIONS_URL" ]];
-	then
-		curl -s -H 'content-type: application/json' \
-			 -d "{ \"text\": \"$(deploy_message end)\" }" \
-			 "$SLACK_NOTIFICATIONS_URL"
-	fi
+	notify_slack "$(deploy_message downtime_end)"
 
+	echo "STEP: Run maintenance/update.php to update DB schema, if required"
+	local php_container_exec="${docker_compose_override} exec php"
+	${php_container_exec} /srv/mediawiki/maintenance/update.php --quick
+
+	notify_slack "$(deploy_message deploy_end)"
 	echo "END: deploying metakgp-wiki"
 }
 

--- a/scripts/deploy-latest.sh
+++ b/scripts/deploy-latest.sh
@@ -128,7 +128,15 @@ deploy () {
 	${php_container_exec} /srv/mediawiki/maintenance/update.php --quick
 
 	notify_slack "$(deploy_message deploy_end)"
-	echo "END: deploying metakgp-wiki"
+
+	cat <<EOF
+END: Deployed metakgp-wiki
+
+Don't forget to try logging in and editing a page to make sure the wiki is working
+
+| Home page   | https://metakgp.org/
+| Random page | https://metakgp.org/w/Special:Random
+EOF
 }
 
 if [[ "$1" == "-h" || "$1" == "--help" ]];

--- a/scripts/deploy-latest.sh
+++ b/scripts/deploy-latest.sh
@@ -6,6 +6,9 @@
 
 # set -x
 
+# TODO:
+# 1. Include the real username (or at least users who are logged in to the server)
+# 2. Include the old commit and the commit that is going to be deployed
 deploy_message () {
 	local action=$1
 	case $action in
@@ -20,7 +23,7 @@ deploy_message () {
 
 # TODO: Better as parameters to the deploy function?
 base_branch="master"
-deploy_branch="master"
+deploy_branch="origin/master"
 
 deploy () {
 	local go="${1}"

--- a/scripts/deploy-latest.sh
+++ b/scripts/deploy-latest.sh
@@ -23,6 +23,8 @@ base_branch="master"
 deploy_branch="master"
 
 deploy () {
+	local go="${1}"
+
 	local source_dir=$(pwd)
 	echo "START: metakgp-wiki deploy"
 
@@ -30,7 +32,7 @@ deploy () {
 	cd "$config_path" || return 2
 
 	echo "STEP: Ensure that current branch is $base_branch"
-	local branch=$(git rev-parse --abbrev-ref HEAD)
+	local branch=$(git rev-parse --abbrev-ref $base_branch)
 	if [[ "$branch" != "$base_branch" ]];
 	then
 		echo "Current branch is not $base_branch. Continue with deployment? (y/N)"
@@ -87,6 +89,12 @@ deploy () {
 	echo "STEP: Deployed version"
 	git log --oneline | head -n1
 
+	if [[ "$go" != "--go" ]];
+	then
+		echo "DRY RUN: Stopping deploy; Run with --go to continue beyond this point"
+		return 0
+	fi
+
 	echo "STEP: Merge branch and build Docker images"
 	git merge --ff-only $deploy_branch
 
@@ -128,8 +136,16 @@ deploy () {
 	echo "END: deploying metakgp-wiki"
 }
 
+if [[ "$1" == "-h" || "$1" == "--help" ]];
+then
+	echo "./deploy-latest.sh [--go]"
+	exit 0
+fi
+
 source_dir=$(pwd)
-deploy
+
+deploy $1
+
 exit_code=$?
 cd "$source_dir"
 exit ${exit_code}

--- a/scripts/deploy-latest.sh
+++ b/scripts/deploy-latest.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+
+# set -x
+
+deploy () {
+	local source_dir=$(pwd)
+	echo "START: metakgp-wiki deploy"
+
+	echo "STEP: Ensure that current branch is master"
+	local branch=$(git rev-parse --abbrev-ref HEAD)
+	if [[ "$branch" != "master" ]];
+	then
+		echo "Current branch is not master. Continue with deployment? (y/N)"
+		read p
+
+		if [[ "$p" != "y" ]];
+		then
+			echo "END: Stopping deployment"
+			return 0
+		fi
+	fi
+
+	echo "STEP: Update repository"
+	git remote update
+
+	echo "STEP: Check if there are any changes that need to be deployed"
+	git --no-pager diff --exit-code origin/master > /dev/null
+
+	if [[ "$?" == "0" ]];
+	then
+		echo "master and origin/master are the same. Continue with deployment? (y/N)"
+		read p
+
+		if [[ "$p" != "y" ]];
+		then
+			echo "END: Stopping deployment"
+			return 0
+		fi
+	fi
+
+	local docker_compose="docker-compose"
+	local docker="docker"
+
+	# TODO: Change default to the server location
+	local config_path=${METAKGP_WIKI_PATH:-$HOME/code/metakgp/metakgp-wiki}
+
+	cd "$config_path"
+
+	# TODO: Fail if docker or docker-compose not found
+	${docker} version
+	${docker_compose} version
+
+	echo "STEP: Running backup job"
+	local backup_container_exec="${docker_compose} -f docker-compose.yml \
+					  -f docker-compose.override.yml \
+					  -f docker-compose.prod.yml exec backup"
+
+	${backup_container_exec} ./run_backup.sh 2>/dev/null
+
+	echo "STEP: Get latest backup and store inside $source_dir/.backups"
+
+	mkdir -p "$source_dir/.backups"
+	# TODO: Strange head commands to get rid of the newlines at the end. Use gawk instead?
+	backup_archive="$(${backup_container_exec} ls -1 -t /root/backups 2>/dev/null | head -1 | head -c -2)"
+	backup_container_name=$(${docker} ps  --format '{{ .Names }}' | grep backup | head -1)
+	backup_path="$backup_container_name:/root/backups/$backup_archive"
+	docker cp "$backup_path" "$source_dir/.backups"
+
+	echo "STEP: Deployed version"
+	git log --oneline | head -n1
+
+
+
+	echo "END: deploying metakgp-wiki"
+}
+
+source_dir=$(pwd)
+deploy
+exit_code=$?
+cd "$source_dir"
+exit ${exit_code}

--- a/scripts/deploy-latest.sh
+++ b/scripts/deploy-latest.sh
@@ -108,10 +108,11 @@ deploy () {
 					  -f docker-compose.override.yml \
 					  -f docker-compose.prod.yml"
 
+	# TODO: Move to a function
 	if [[ -n "$SLACK_NOTIFICATIONS_URL" ]];
 	then
 		curl -s -H 'content-type: application/json' \
-			 -d '{ "text": "'$(deploy_message "start")'" }' \
+			 -d "{ \"text\": \"$(deploy_message start)\" }" \
 			 "$SLACK_NOTIFICATIONS_URL"
 	fi
 
@@ -126,10 +127,11 @@ deploy () {
 
 	echo "STEP: Bring all containers down (Downtime end) $(date +%s)"
 
+	# TODO: Move to a function
 	if [[ -n "$SLACK_NOTIFICATIONS_URL" ]];
 	then
 		curl -s -H 'content-type: application/json' \
-			 -d '{ "text": "'$(deploy_message "start")'" }' \
+			 -d "{ \"text\": \"$(deploy_message end)\" }" \
 			 "$SLACK_NOTIFICATIONS_URL"
 	fi
 


### PR DESCRIPTION
## Summary

We run the same set of commands each time to deploy new versions of the configuration. This PR adds a script which will reduce the manual input required for a re-deploy to simply running the script as root.

This script will also post notifications to the #server channel: 

![image](https://user-images.githubusercontent.com/3668034/85303458-7a43de00-b4e5-11ea-98ff-468553c75159.png)

This reduces another manual step in the deployment process that the person deploying needs to worry about.

This script is still WIP. I plan to improve it in future PRs. Several of the TODO notes can be fixed / removed now if reviewers have strong opinions one way or the other. If not, we can leave them in the script for now and decide later.