### PR TITLE
Fix Scribunto Issues

### DIFF
--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -25,7 +25,7 @@ command without that flag at the end.
 ### Deprecated
 
 **Note:** Manual operation for regular configuration updates is now deprecated. Please use the
-deploy script: [./script/deploy-latest.sh](./script/deploy-latest.sh).
+deploy script: [./scripts/deploy-latest.sh](./scripts/deploy-latest.sh).
 
 1. Take a backup! Run `docker-compose -f docker-compose.yml -f docker-compose.override.yml -f docker-compose.prod.yml exec backup ./run_backup.sh` and make sure it succeeded. Also run `git log` and note down the current deployed sha, in case you need to roll back.
 1. `git pull` and `docker-compose build`. This builds and caches the new images locally without interrupting the old server, which reduces downtime.

--- a/mediawiki/LocalSettings.php
+++ b/mediawiki/LocalSettings.php
@@ -169,9 +169,6 @@ $wgDefaultUserOptions['usebetatoolbar-cgd'] = 1;
 $wgDefaultUserOptions['wikieditor-preview'] = 1;
 #$wgDefaultUserOptions['wikieditor-publish'] = 1;
 
-#$wgScribuntoDefaultEngine = 'luastandalone';
-#$wgScribuntoUseGeSHi = true;
-
 $wgLocaltimezone = "Asia/Kolkata";
 date_default_timezone_set( $wgLocaltimezone );
 

--- a/mediawiki/LocalSettings.php
+++ b/mediawiki/LocalSettings.php
@@ -169,8 +169,8 @@ $wgDefaultUserOptions['usebetatoolbar-cgd'] = 1;
 $wgDefaultUserOptions['wikieditor-preview'] = 1;
 #$wgDefaultUserOptions['wikieditor-publish'] = 1;
 
-$wgScribuntoDefaultEngine = 'luastandalone';
-$wgScribuntoUseGeSHi = true;
+#$wgScribuntoDefaultEngine = 'luastandalone';
+#$wgScribuntoUseGeSHi = true;
 
 $wgLocaltimezone = "Asia/Kolkata";
 date_default_timezone_set( $wgLocaltimezone );
@@ -473,3 +473,7 @@ $wgSpamBlacklistFiles = array(
    "[[m:Spam blacklist]]", # from meta-wiki
    "https://en.wikipedia.org/wiki/MediaWiki:Spam-blacklist" # from wikipedia
 );
+
+# Scribunto Extension, bundled with MediaWiki 1.34
+wfLoadExtension( 'Scribunto' );
+$wgScribuntoDefaultEngine = 'luastandalone';


### PR DESCRIPTION
This PR does 2 things: 
1. Load the `Scribunto` extension inside `LocalSettings.php` using `wfLoadExtension`. `Scribunto` comes bundled with Mediawiki 1.34 and doesn't need to be downloaded. For the extension to work properly, path to a Lua executable must be given and made executable, which is done inside `mediawiki/install_extensions.sh`.  
2. Fix the path of deplo script inside `RUNBOOK.md` (./script -> ./scripts)

`$wgScribuntoUseGeSHi = true` is commented inside `mediawiki/LocalSettings.php` as it is needed for Mediawiki <= 1.30 ([Source](https://www.mediawiki.org/wiki/Extension:Scribunto#Optional_Installation))