### PR TITLE
[FIX] Update requirements.txt for popular pages & trending pages script

### DIFF
--- a/jobs/requirements.txt
+++ b/jobs/requirements.txt
@@ -1,2 +1,3 @@
 requests>=2.18.4<3.0
 google-api-python-client>=1.6.3<2.0
+oauth2client==4.1.3


### PR DESCRIPTION
As @amrav pointed out in the slack channel, jobs have not been running for a while for updating popular pages and trending pages. On looking at the logs, I found the below interesting message,

`time="2020-07-26T01:11:02+05:30" level=info msg="ImportError: No module named oauth2client.service_account" channel=stderr iteration=5 job.command="/root/update_top_trending.sh" job.position=0 job.schedule="11 * * * *"`

As can be clearly seen, a python package is amiss. A quick search led me [to the solution](https://stackoverflow.com/questions/37850004/gspread-importerror-no-module-named-oauth2client-service-account). Hence, `oauth2client` was added to the requirements.txt

---
#### Testing

I tested the same by opening an interactive shell, installing the dependency, and running the script manually. The script ran perfectly and the [main page](https://wiki.metakgp.org/w/Main_Page) was updated!