### PR TITLE
git diff comparison will happen with base_branch

### DIFF
--- a/scripts/deploy-latest.sh
+++ b/scripts/deploy-latest.sh
@@ -61,7 +61,7 @@ deploy () {
 	git remote update
 
 	echo "STEP: Check if there are any changes that need to be deployed"
-	git --no-pager diff --exit-code $deploy_branch > /dev/null
+	git --no-pager diff --exit-code $base_branch > /dev/null
 
 	local docker_compose="docker-compose"
 	local docker="docker"


### PR DESCRIPTION
This resolves the issue that the comparison in the `deploy-latest.sh` script happens between the current local master and origin/master. This exits the deployment unless origin/master has been merged beforehand which adds an undesirable manual step.

A proposed solution is to do `git diff` with the base_branch which would exit if there are manual changes that have not been committed. In case some committed changes are there, as per [line number 100](https://github.com/metakgp/metakgp-wiki/blob/e74b58660e13f6cefb3d0c64e627bbaa16478329/scripts/deploy-latest.sh#L100), fast-forward merging will fail and the deployment will halt. 

