### PR TITLE
notify slack only on `--go` runs of deploy-latest

### DIFF
--- a/scripts/deploy-latest.sh
+++ b/scripts/deploy-latest.sh
@@ -44,7 +44,10 @@ deploy_branch="origin/master"
 deploy () {
 	local go="${1}"
 
-	notify_slack "$(deploy_message deploy_start)"
+	if [[ "$go" == "--go" ]];
+	then
+		notify_slack "$(deploy_message deploy_start)"
+	fi
 
 	local source_dir=$(pwd)
 	echo "START: metakgp-wiki deploy"


### PR DESCRIPTION
As per discussion with @icyflame , Slack notifications should not be happening for dry runs. This PR implements the same.