### PR TITLE
Added configuration for Slow query log

### DIFF
--- a/mysql/Dockerfile
+++ b/mysql/Dockerfile
@@ -1,1 +1,4 @@
 FROM mysql:5.7
+
+COPY ./mysqld.cnf /etc/mysql/mysql.conf.d/mysqld.cnf
+

--- a/mysql/mysqld.cnf
+++ b/mysql/mysqld.cnf
@@ -1,0 +1,10 @@
+[mysqld]
+pid-file = /var/run/mysqld/mysqld.pid
+socket = /var/run/mysqld/mysqld.sock
+datadir = /var/lib/mysql
+symbolic-links=0
+
+# Slow query settings:
+slow_query_log=1
+slow_query_log_file=/var/log/mysql/slow.log
+long_query_time=5.0


### PR DESCRIPTION
Followed this: https://gist.github.com/akirattii/40b284332e887f2f3dcdc4bca08517a5
Tested that the `slow.log` appears at `/var/log/mysql/` inside the image.