### PR TITLE
[WIP] Add Ingress Update

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -7,8 +7,6 @@ services:
   nginx:
     volumes:
       - mediawiki-volume:/srv/mediawiki
-    ports:
-      - "${SERVER_PORT:-8080}:80"
   php:
     volumes:
       - mediawiki-volume:/srv/mediawiki

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -2,6 +2,8 @@ version: '2.1'
 
 services:
   nginx:
+    networks:
+      nginx_network:
     volumes:
       - static-volume:/srv/static
   php:
@@ -34,3 +36,5 @@ volumes:
 
 networks:
   mysql_network:
+  external:
+    name: nginx_network

--- a/nginx/static.metakgp.org
+++ b/nginx/static.metakgp.org
@@ -1,6 +1,6 @@
 server {
         # listen 8080 default_server;
-	listen 80;
+	listen 8082;
 	# listen [::]:80 default_server ipv6only=on;
 
 	root /srv/static;

--- a/nginx/wiki.metakgp.org
+++ b/nginx/wiki.metakgp.org
@@ -1,6 +1,6 @@
 server {
         # listen 8080 default_server;
-	listen 80 default_server;
+	listen 8082 default_server;
 	# listen [::]:80 default_server ipv6only=on;
 
 	root /srv/mediawiki;


### PR DESCRIPTION
As discussed, we plan on using [ingress](https://github.com/grapheo12/ingress) to serve multiple applications on the wiki server and save costs.

This PR aims at bringing in the required changes to allow connection with ingress by wiki.

In the ingress, we have dedicated port 8082 to wiki and hence Nginx should listen on 8082 where all connections coming to the domain wiki.metakgp.org and static.metakgp.org will be proxied.

We have decided to allow each application to have it's own Nginx instance as well which would give independency and we will simply proxy HTTP and HTTPS requests to the concerned ports. This will also allow the applications to manage serving static files by themselves. @icyflame @amrav Do you think this is a valid approach? I'm pretty skeptical about this since I've never tried the same before and your experience would be valuable here.

NOTE: This is a provisional PR and we will be incorporating feedback and our testing results.

cc/ @grapheo12