### PR TITLE
Added Ingress specific changes (backwards compatible)

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -5,10 +5,11 @@ services:
     volumes:
       - db-volume:/var/lib/mysql
   nginx:
+    container_name: 'wiki-nginx'
     volumes:
       - mediawiki-volume:/srv/mediawiki
-    ports:
-      - "${SERVER_PORT:-8080}:80"
+    networks:
+      nginx-network:
   php:
     volumes:
       - mediawiki-volume:/srv/mediawiki
@@ -19,3 +20,6 @@ services:
 volumes:
   mediawiki-volume:
   db-volume:
+
+networks:
+  nginx-network:


### PR DESCRIPTION
After @thealphadollar 's changes to [ingress](https://github.com/grapheo12/ingress), there were some problems which I corrected. 

After testing, I came up with this simple config:

Now we do not need to specify ports for wiki. It can listen to port 80. However, we need a fixed container name (which this PR fixes) and a fixed network name (also ensured by this PR and partly ensured by the naming convention of docker-compose).

See the current ingress docker-compose for the use of `metakgp-wiki_nginx-network`.

This makes the changes backwards compatible, meaning, even without Ingress, wiki would run without any change to the docker-compose file. Just then port forwarding has to be done manually.

If this is merged, #95 would become stale.
