### PR TITLE
[jobs]Feat: mysql log rotation

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -24,3 +24,4 @@ services:
       - GOOGLE_ANALYTICS_SERVICE_KEY=$GOOGLE_ANALYTICS_SERVICE_KEY
     volumes:
       - mediawiki-volume:/srv/mediawiki
+      - db-volume:/var/lib/mysql

--- a/jobs/Dockerfile
+++ b/jobs/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3-slim
 
-RUN apt-get update && apt-get install -y wget curl
+RUN apt-get update && apt-get install -y wget curl logrotate
 
 ENV TZ=Asia/Kolkata
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
@@ -27,6 +27,7 @@ COPY pywikibot/user-config.py pywikibot/user-password.py pywikibot/
 COPY pywikibot/metakgp_family.py pywikibot/pywikibot/families/
 COPY pywikibot/scripts/ pywikibot/scripts/
 
-COPY crontab update_top_trending.sh MetaMaint.sh update_spam_denylist.sh ./
+COPY crontab update_top_trending.sh MetaMaint.sh update_spam_denylist.sh mysql_logrotate.conf ./
+RUN chmod 644 mysql_logrotate.conf && groupadd -g 999 mysql && useradd mysql -u 999 -g 999
 
 CMD ["supercronic", "/root/crontab"]

--- a/jobs/crontab
+++ b/jobs/crontab
@@ -3,3 +3,4 @@
 11 * * * * /root/update_top_trending.sh
 13 3 * * 1 /root/MetaMaint.sh
 47 3 * * * /root/update_spam_denylist.sh
+02 3 * * * logrotate mysql_logrotate.conf

--- a/jobs/mysql_logrotate.conf
+++ b/jobs/mysql_logrotate.conf
@@ -1,0 +1,7 @@
+/var/lib/mysql/*.log {
+    su mysql mysql
+    rotate 1
+    size 1G
+    nocompress
+    copytruncate
+}

--- a/mysql/mysqld.cnf
+++ b/mysql/mysqld.cnf
@@ -1,5 +1,6 @@
 [mysqld]
-general_log=1
+general_log=1   
+general_log_file = /var/lib/mysql/mysql.log
 
 # Slow query settings:
 slow_query_log=1
@@ -8,3 +9,5 @@ long_query_time=5.0
 
 # Error logging
 log_error=/var/lib/mysql/mysql_error.log
+
+innodb_temp_data_file_path=ibtmp1:12M:autoextend:max:5G


### PR DESCRIPTION
Implement cron job which runs `logrotate` on 03:02 AM everyday.
If the size of any of the log files in `/var/lib/mysql/` goes above 1GB, it makes a copy of that file and empties the main log file. That copy is deleted and a new copy made when the main file goes over 1GB again.