### PR TITLE
Disable DNS Blacklist

### DIFF
--- a/mediawiki/LocalSettings.php
+++ b/mediawiki/LocalSettings.php
@@ -346,8 +346,8 @@ $wgGroupPermissions['sysop']['checkuser'] = true;
 $wgGroupPermissions['sysop']['checkuser-log'] = true;
 
 # DNS-based real-time spam blacklist
-$wgEnableDnsBlacklist = true;
-$wgDnsBlacklistUrls = array('sbl.spamhaus.org.');
+$wgEnableDnsBlacklist = false;
+// $wgDnsBlacklistUrls = array('sbl.spamhaus.org.');
 
 wfLoadExtension('SimpleBatchUpload');
 


### PR DESCRIPTION
Users are unable to create accounts due to their IP getting blocked. Temporary fix is to disable the DNSBL option.